### PR TITLE
Fix answer button state in quiz

### DIFF
--- a/Quiz/Assets/Scripts/Quiz.cs
+++ b/Quiz/Assets/Scripts/Quiz.cs
@@ -135,7 +135,7 @@ public class Quiz : MonoBehaviour
     {
         for (int i = 0; i < answerButtons.Length; i++)
         {
-            Button button = answerButtons[1].GetComponent<Button>();
+            Button button = answerButtons[i].GetComponent<Button>();
             button.interactable = state;
         }
     }


### PR DESCRIPTION
## Summary
- fix interaction state for quiz answer buttons by looping over all buttons

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68416c15876c8325a5ed66e8875ad31d